### PR TITLE
Use EphemeralChat for communicating the Slack Secret

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -34,7 +34,7 @@ app.post('/register', async (req, res) => {
 			text: "Your secret is " + userSecret
 	}};
 
-	request.post('https://slack.com/api/chat.postMessage', data, function (error, response, body) {
+	request.post('https://slack.com/api/chat.postEphemeral', data, function (error, response, body) {
 		res.json();
 	});
 });

--- a/server/server.js
+++ b/server/server.js
@@ -31,6 +31,7 @@ app.post('/register', async (req, res) => {
 		form: {
 			token: process.env.SLACK_AUTH_TOKEN,
 			channel: channelId,
+			user: userId,
 			text: "Your secret is " + userSecret
 	}};
 


### PR DESCRIPTION
Secret key is responded by the bot in public mode. 
Altering the API endpoint, we can make this message to be only seen by the requester